### PR TITLE
Added flag for knative-serving condition

### DIFF
--- a/charts/kubeflow/Chart.yaml
+++ b/charts/kubeflow/Chart.yaml
@@ -41,6 +41,7 @@ dependencies:
     condition: istio.enabled
   - name: knative-serving
     version: "1.2.5"
+    condition: knative-serving.enabled
   - name: minio
     version: "1.0"
     condition: minio.enabled


### PR DESCRIPTION
related to: https://github.com/alauda/kubeflow-chart/issues/41

An very small adjustment to allow disabling of knative-serving chart. This should be backwards compatible since the default is true before and after.

